### PR TITLE
Fix missing directive registration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import { createApp } from 'vue'
 import './style.css'
 import App from './App.vue'
+import { canvasDirective } from './directives/canvas'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.directive('canvas', canvasDirective)
+app.mount('#app')


### PR DESCRIPTION
## Summary
- register the custom canvas directive

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e52291d248325857ec9e3b55b09a6
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Registered the custom canvas directive so it can be used in Vue components.

<!-- End of auto-generated description by cubic. -->

